### PR TITLE
fix(README & week_1): Fix typo and suboptimal grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CCNS golang language study group at 2020 spring.
 
 ## Content
 - Markdown file notes
-- Example code for demostration
+- Example code for demonstration
 - Others study-group-related files
 
 ## Structure

--- a/week_1/ch_2/name/naming.go
+++ b/week_1/ch_2/name/naming.go
@@ -5,7 +5,7 @@ package main
 // var _123 int
 // var fooBar int
 
-// not recommand
+// not recommended
 // var foo_bar int
 
 // syntax error

--- a/week_1/ch_2/name/scope.go
+++ b/week_1/ch_2/name/scope.go
@@ -8,7 +8,7 @@ var _foo int = 0
 
 func foo() {
 
-	// unused, because of not accessable out of func
+	// unused, because of not accessible out of func
 	// var _foo int = 1
 }
 

--- a/week_1/ch_2/package/package.go
+++ b/week_1/ch_2/package/package.go
@@ -2,10 +2,10 @@
 // expected 'package', found 'func'
 package main
 
-// dupclicate may cause :
+// duplicate may cause :
 // syntax error: non-declaration statement outside function body
 // package sub
 
 // skip may cause :
 // function main is undeclared in the main package
-func main() { /* Do somthing*/ }
+func main() { /* Do something*/ }

--- a/week_1/note.md
+++ b/week_1/note.md
@@ -10,7 +10,7 @@ tags: CCNS
 
 ----
 
-# 1.1 Hello world
+# 1.1 Hello World
 
 - Standard IO
 
@@ -97,7 +97,7 @@ func main() {
 ```
 ----
 
-# 1.3 Finding Duplicate Lines
+# 1.3 Finding Duplicated Lines
 
 - 事實上，我們很少拿 Golang 來進行複雜的字串操作
 
@@ -168,7 +168,7 @@ func main() {
 
 ----
 
-# 1.6 fetch Concurrently
+# 1.6 Fetch Concurrently
 
 - fetch concurrently
 
@@ -220,7 +220,7 @@ func fetch(url string, ch chan<- string) {
 
 ----
 
-# 1.7 Web server
+# 1.7 Web Server
 
 ## server_1
 
@@ -346,7 +346,7 @@ var _foo int
 var _123 int
 var fooBar int
 
-// not recommand
+// not recommended
 var foo_bar int
 
 // syntax error
@@ -371,7 +371,7 @@ var _foo int = 0
 
 func foo() {
 
-	// unused, because of not accessable out of func
+	// unused, because of not accessible out of func
 	// var _foo int = 1
 }
 
@@ -415,13 +415,13 @@ func main() {
 // expected 'package', found 'func'
 package main
 
-// dupclicate may cause :
+// duplicate may cause :
 // syntax error: non-declaration statement outside function body
 // package sub
 
 // skip may cause :
 // function main is undeclared in the main package
-func main() { /* Do somthing*/ }
+func main() { /* Do something*/ }
 ```
 
 ----
@@ -434,13 +434,13 @@ package main
 // single package import
 import "fmt"
 
-// multiple packages import
+// multiple package import
 import (
   "fmt"
   "os"
 )
 
-// prefered arrangement
+// preferred arrangement
 import (
   "standard packages"
   
@@ -453,12 +453,12 @@ import (
 ----
 
 ## var
-  - default value, no un-init var
+  - default value, no un-inited var
   - auto type map with list or func call
   - init 時機
     - 執行前
     - 被 import 前
-  - short declare(a declare, = is assign), error if re-declare
+  - short declare(a declaration, = is assignment), error if re-declare
 
 ```go=
 package main
@@ -563,8 +563,8 @@ func main() {
 ----
 
 ## type
-  - struct declare 十分重要，為程式架構核心能力
-  - 留意 compareable
+  - struct declaration 十分重要，為程式架構核心能力
+  - 留意 comparable
 
 ```go=
 package main


### PR DESCRIPTION
- README.md
   - Fix typo
      - `demostration` -> `demonstration`
- week_1/note.md
   - Fix incorrect word inflection
      - `Duplicate Lines` -> `Duplicated Lines`
      - `multiple packages import` -> `multiple package import`
         - Only nouns in singular form can be used as adjectives
      - `no un-init var` -> `no un-inited var`
      - `a declare, = is assign` -> `a declaration, = is assignment`
      - `struct declare` -> `struct declaration`
   - Make `#` title texts to be in title case
   - Fix typo
      - `prefered` -> `preferred`
      - `compareable` -> `comparable`
      - Other typos in the example codes
- week_1/ch_2/name/nameing.go -> week_1/ch_2/name/naming.go
   - Fix typo
      - The file name itself is a typo
      - `not recommand` -> `not recommended`
         - This is also a word inflection error
- week_1/ch_2/name/scope.go
   - Fix typo
      - `accessable` -> `accessible`
- week_1/ch_2/package/package.go:
   - Fix typo
      - `dupclicate` -> `duplicate`
      - `Do somthing` -> `Do something`